### PR TITLE
受講者情報と投稿をscopeにまとめた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'figaro', '~> 1.1', '>= 1.1.1'
 gem 'kaminari', '~> 1.1', '>= 1.1.1'
 gem 'haml-rails'
 gem 'erb2haml'
+gem 'enum_help'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erb2haml (0.1.5)
       html2haml
     erubi (1.8.0)
@@ -320,6 +322,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise (~> 4.6, >= 4.6.1)
+  enum_help
   erb2haml
   factory_bot_rails (~> 4.11, >= 4.11.1)
   figaro (~> 1.1, >= 1.1.1)

--- a/app/controllers/recruitments_controller.rb
+++ b/app/controllers/recruitments_controller.rb
@@ -3,7 +3,7 @@ class RecruitmentsController < ApplicationController
   before_action :set_recruitment, only: [:show, :edit, :update, :destroy]
 
   def index
-    @recruitments = Recruitment.page(params[:page]).per(9).recent.includes(:user)
+    @recruitments = Recruitment.page(params[:page]).per(9).recents.includes(:user)
   end
 
   def show

--- a/app/controllers/recruitments_controller.rb
+++ b/app/controllers/recruitments_controller.rb
@@ -3,7 +3,7 @@ class RecruitmentsController < ApplicationController
   before_action :set_recruitment, only: [:show, :edit, :update, :destroy]
 
   def index
-    @recruitments = Recruitment.page(params[:page]).per(9).recents.includes(:user)
+    @recruitments = Recruitment.page(params[:page]).per(9).recent.includes(:user)
   end
 
   def show

--- a/app/controllers/student_controller.rb
+++ b/app/controllers/student_controller.rb
@@ -1,5 +1,5 @@
 class StudentController < ApplicationController
   def index
-    @students = Recruitment.by_student.includes(:user)
+    @students = Recruitment.by_students.includes(:user)
   end
 end

--- a/app/controllers/student_controller.rb
+++ b/app/controllers/student_controller.rb
@@ -1,6 +1,5 @@
 class StudentController < ApplicationController
   def index
-    @users = User.where("person_type = 0")
-    @students = @users.map { |user| user }
+    @students = Recruitment.by_student.includes(:user)
   end
 end

--- a/app/models/recruitment.rb
+++ b/app/models/recruitment.rb
@@ -7,4 +7,5 @@ class Recruitment < ApplicationRecord
   validates :content, presence: true, length: {maximum: 1000}
 
   scope :recent, -> { order('created_at desc') }
+  scope :by_student, -> { joins(:user).merge(User.student) }
 end

--- a/app/models/recruitment.rb
+++ b/app/models/recruitment.rb
@@ -6,6 +6,6 @@ class Recruitment < ApplicationRecord
   validates :title, presence: true, length: {maximum: 30}
   validates :content, presence: true, length: {maximum: 1000}
 
-  scope :recents, -> { order('created_at desc') }
-  scope :by_students, -> { joins(:user).merge(User.students) }
+  scope :recent, -> { order('created_at desc') }
+  scope :by_students, -> { joins(:user).merge(User.student) }
 end

--- a/app/models/recruitment.rb
+++ b/app/models/recruitment.rb
@@ -6,6 +6,6 @@ class Recruitment < ApplicationRecord
   validates :title, presence: true, length: {maximum: 30}
   validates :content, presence: true, length: {maximum: 1000}
 
-  scope :recent, -> { order('created_at desc') }
-  scope :by_student, -> { joins(:user).merge(User.student) }
+  scope :recents, -> { order('created_at desc') }
+  scope :by_students, -> { joins(:user).merge(User.students) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users
 
 
+  scope :student, -> { where("person_type = 0") }
 
   enum prefecture: {
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users
 
 
-  scope :student, -> { where("person_type = 0") }
+  scope :students, -> { where(person_type: person_type[:student]) }
 
   enum prefecture: {
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
@@ -24,7 +24,7 @@ class User < ApplicationRecord
     福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47
   }
 
-  enum person_type: { 受講者: 0, 指導者: 1 }
+  enum person_type: { student: 0, teacher: 1 }
   enum sex: { 男性: 0, 女性: 1 }
 
   #validation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users
 
 
-  scope :students, -> { where(person_type: person_type[:student]) }
+  scope :student, -> { where(person_type: person_type[:student]) }
 
   enum prefecture: {
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -14,10 +14,10 @@
         = f.email_field :email, placeholder: "メールアドレス", class: "email-form"
       .new-person-type
         .radio_button
-          = f.radio_button :person_type, "受講者", class: "type-form", id: "inlineRadio1"
+          = f.radio_button :person_type, "student", class: "type-form", id: "inlineRadio1"
           %label.form-check-label{:for => "inlineRadio1"} 受講者
         .radio_button
-          = f.radio_button :person_type, "指導者", class: "type-form", id: "inlineRadio2"
+          = f.radio_button :person_type, "teacher", class: "type-form", id: "inlineRadio2"
           %label.form-check-label{:for => "inlineRadio2"} 指導者
       .new-sex
         .l-sex.user-title

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -14,10 +14,10 @@
         = f.password_field :password_confirmation,  placeholder: "パスワードの確認", class: "pass-form"
       .new-person-type
         .radio_button
-          = f.radio_button :person_type, "受講者", class: "type-form", id: "inlineRadio1"
+          = f.radio_button :person_type, "student", class: "type-form", id: "inlineRadio1"
           %label.form-check-label{:for => "inlineRadio1"} 受講者
         .radio_button
-          = f.radio_button :person_type, "指導者", class: "type-form", id: "inlineRadio2"
+          = f.radio_button :person_type, "teacher", class: "type-form", id: "inlineRadio2"
           %label.form-check-label{:for => "inlineRadio2"} 指導者
       .new-prefecture
         .pref-title.user-title

--- a/app/views/student/_main.html.haml
+++ b/app/views/student/_main.html.haml
@@ -1,17 +1,16 @@
 - students.each do |student|
-  - student.recruitments.each do |recruitment|
-    .each-p
-      .p-upper
-        .p-user
-          %p
-            = image_tag("user.png", :alt => "募集者の画像", :class => "user-pic")
-          .user-name
-            %p= student.name
-          .user-pref
-            %p= student.prefecture
-        .p-title
-          %h2= truncate(recruitment.title, length: 20)
-      .p-content
-        = link_to recruitment_path(recruitment), class: "link" do
-          %p
-            = truncate(recruitment.content, length: 50)
+  .each-p
+    .p-upper
+      .p-user
+        %p
+          = image_tag("user.png", :alt => "募集者の画像", :class => "user-pic")
+        .user-name
+          %p= student.user.name
+        .user-pref
+          %p= student.user.prefecture
+      .p-title
+        %h2= truncate(student.title, length: 20)
+    .p-content
+      = link_to recruitment_path(student), class: "link" do
+        %p
+          = truncate(student.content, length: 50)

--- a/app/views/student/index.html.haml
+++ b/app/views/student/index.html.haml
@@ -4,4 +4,4 @@
   .side
     = render 'recruitments/sidebar'
   .main-p
-    = render partial: 'main', locals: { students: @students, recruitments: @recruitments }
+    = render partial: 'main', locals: { students: @students }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -11,7 +11,7 @@
             = @user.name
         .user-prof.m-t
           %span.u-type
-            = @user.person_type
+            = @user.person_type_i18n
           %span.u-pref
             = @user.prefecture
           %span.u-age

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  enums:
+    user:
+      person_type:
+        student: 受講者
+        teacher: 指導者


### PR DESCRIPTION
## 概要
student_controllerに書いていた受講者情報をモデルでscopeを作り、そこにまとめた。

そうすることで、student_controllerの記述が1行になり、viewに関しても「全投稿」「指導者」「受講者」の投稿一覧ページを１つにまとめる事が出来ると期待する。

※尚、PRの粒度を小さくするために今回は受講者だけの変更で、次に指導者においても同じ変更をする。


編集参考ページ
https://qiita.com/tkhr/items/9b79bce27f20191eb78f